### PR TITLE
Update Gradle setup action to v4 and add missing setup step

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,7 +22,7 @@ jobs:
           distribution: 'temurin'
           java-version: '21'
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v4
       - name: Decode debug keystore
         env:
           DEBUG_KEYSTORE_BASE64: ${{ secrets.DEBUG_KEYSTORE_BASE64 }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,9 @@ jobs:
           distribution: 'temurin'
           java-version: '21'
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
       - run: ./gradlew :app-android:assembleRelease
 
       - env:


### PR DESCRIPTION
## Summary
Updates the Gradle setup action to the latest version (v4) across CI/CD workflows and adds the missing Gradle setup step to the release workflow.

## Key Changes
- Updated `gradle/gradle-build-action@v3` to `gradle/actions/setup-gradle@v4` in the build workflow
- Added `gradle/actions/setup-gradle@v4` setup step to the release workflow (was previously missing)

## Details
The Gradle team has migrated their action to a new namespace (`gradle/actions/setup-gradle`) and released v4 with improvements and bug fixes. This change ensures:
- Consistent Gradle setup across all workflows
- Access to the latest Gradle action features and fixes
- Proper Gradle environment initialization in the release workflow before running the assembleRelease task

https://claude.ai/code/session_01Rtqxiy3iNFbFcnVVxoRmZ5