### PR TITLE
Thinking対応モデルの表示名に接尾辞を追加

### DIFF
--- a/src/commonMain/kotlin/net/matsudamper/gptclient/entity/ChatGptModel.kt
+++ b/src/commonMain/kotlin/net/matsudamper/gptclient/entity/ChatGptModel.kt
@@ -259,3 +259,11 @@ interface ChatGptModel {
         }
     }
 }
+
+fun ChatGptModel.getDisplayNameForChat(): String {
+    return if (thinkingToggleEnabled) {
+        "$displayName Thinking"
+    } else {
+        displayName
+    }
+}

--- a/src/commonMain/kotlin/net/matsudamper/gptclient/viewmodel/ChatViewModel.kt
+++ b/src/commonMain/kotlin/net/matsudamper/gptclient/viewmodel/ChatViewModel.kt
@@ -21,6 +21,7 @@ import net.matsudamper.gptclient.MediaRequest
 import net.matsudamper.gptclient.PlatformRequest
 import net.matsudamper.gptclient.datastore.GeminiBillingKeyOverrideStore
 import net.matsudamper.gptclient.entity.ChatGptModel
+import net.matsudamper.gptclient.entity.getDisplayNameForChat
 import net.matsudamper.gptclient.entity.getName
 import net.matsudamper.gptclient.localmodel.LocalModelDefinition
 import net.matsudamper.gptclient.localmodel.LocalModelId
@@ -180,7 +181,7 @@ class ChatViewModel(
                                 else -> null
                             }
                             ChatListUiState.ModelInfo(
-                                modelName = model.displayName,
+                                modelName = model.getDisplayNameForChat(),
                                 description = description,
                             )
                         },

--- a/src/commonMain/kotlin/net/matsudamper/gptclient/viewmodel/ModelSelectorStateFactory.kt
+++ b/src/commonMain/kotlin/net/matsudamper/gptclient/viewmodel/ModelSelectorStateFactory.kt
@@ -1,6 +1,7 @@
 package net.matsudamper.gptclient.viewmodel
 
 import net.matsudamper.gptclient.entity.ChatGptModel
+import net.matsudamper.gptclient.entity.getDisplayNameForChat
 import net.matsudamper.gptclient.localmodel.LocalModelDefinition
 import net.matsudamper.gptclient.localmodel.LocalModelId
 import net.matsudamper.gptclient.localmodel.toChatGptModel
@@ -21,7 +22,7 @@ internal object ModelSelectorStateFactory {
         )
 
         return ModelSelectorUiState(
-            selectedModelName = selectedModel?.displayName ?: "モデルを選択",
+            selectedModelName = selectedModel?.getDisplayNameForChat() ?: "モデルを選択",
             items = selectableModels.map { model ->
                 ModelSelectorUiState.Item(
                     modelName = model.displayName,


### PR DESCRIPTION
### Motivation
- Thinking を選べるモデルが明確になるよう、表示名の末尾に半角スペース＋`Thinking` を付与する挙動を共通化するための変更です。

### Description
- `ChatGptModel` に `getDisplayNameForChat()` を追加し、`thinkingToggleEnabled == true` の場合は `"<displayName> Thinking"` を返すように実装しました。
- チャット画面のモデル表示生成箇所で `ChatListUiState.ModelInfo.modelName` を `model.getDisplayNameForChat()` に置き換えました。
- モデルセレクターの選択中モデル名生成箇所で `selectedModelName` を `selectedModel?.getDisplayNameForChat()` に置き換えました。

### Testing
- `./gradlew :runKtlintCheckOverCommonMainSourceSet` を実行して成功しました。
- `./gradlew ktlintCheck` を実行したところ `src/jvmMain/kotlin/net/matsudamper/gptclient/JvmAppStorage.kt` の命名規約違反により失敗しましたがこれは本変更範囲外の既存の問題です。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7d885dd548325ac2d605b926210c8)