### PR TITLE
Add image resizing and improve JPEG compression quality

### DIFF
--- a/app-desktop/src/jvmMain/kotlin/net/matsudamper/gptclient/DesktopPlatformRequest.kt
+++ b/app-desktop/src/jvmMain/kotlin/net/matsudamper/gptclient/DesktopPlatformRequest.kt
@@ -1,6 +1,7 @@
 package net.matsudamper.gptclient
 
 import java.awt.Desktop
+import java.awt.RenderingHints
 import java.awt.Toolkit
 import java.awt.datatransfer.StringSelection
 import java.awt.image.BufferedImage
@@ -8,7 +9,10 @@ import java.io.File
 import java.net.URI
 import java.nio.charset.StandardCharsets
 import java.security.MessageDigest
+import javax.imageio.IIOImage
 import javax.imageio.ImageIO
+import javax.imageio.ImageWriteParam
+import javax.imageio.stream.FileImageOutputStream
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
@@ -58,7 +62,8 @@ class DesktopPlatformRequest : PlatformRequest {
             runCatching {
                 val file = File(uri)
                 val image = ImageIO.read(file) ?: return@withContext null
-                val outputImage = cropRect?.let { image.crop(it) } ?: image
+                val outputImage = (cropRect?.let { image.crop(it) } ?: image)
+                    .resizeIfNeeded(MAX_IMAGE_DIMENSION)
                 val outputFormat = imageFormat.toWritableFormat()
                 val hash = buildString {
                     append(file.absolutePath)
@@ -76,6 +81,10 @@ class DesktopPlatformRequest : PlatformRequest {
                     append(file.lastModified())
                     append('|')
                     append(file.sha256Hex())
+                    append('|')
+                    append(MAX_IMAGE_DIMENSION)
+                    append('|')
+                    append(LOSSY_IMAGE_QUALITY)
                 }.sha256Hex()
                 val outputFile = File(
                     System.getProperty("java.io.tmpdir"),
@@ -93,6 +102,19 @@ class DesktopPlatformRequest : PlatformRequest {
 
     override fun createNotificationChannel(channelId: String) {
         // デスクトップでは何もしない
+    }
+
+    private fun BufferedImage.resizeIfNeeded(maxDimension: Int): BufferedImage {
+        if (width <= maxDimension && height <= maxDimension) return this
+        val scale = maxDimension.toDouble() / maxOf(width, height)
+        val newWidth = (width * scale).toInt()
+        val newHeight = (height * scale).toInt()
+        val resized = BufferedImage(newWidth, newHeight, type)
+        val g2d = resized.createGraphics()
+        g2d.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BILINEAR)
+        g2d.drawImage(this, 0, 0, newWidth, newHeight, null)
+        g2d.dispose()
+        return resized
     }
 
     private fun BufferedImage.crop(cropRect: PlatformRequest.CropRect): BufferedImage {
@@ -114,12 +136,22 @@ class DesktopPlatformRequest : PlatformRequest {
         image: BufferedImage,
         imageFormat: ImageFormat,
     ) {
-        val writerFormat = when (imageFormat) {
-            ImageFormat.Jpeg -> "jpg"
-            ImageFormat.Png -> "png"
+        when (imageFormat) {
+            ImageFormat.Jpeg -> {
+                val writer = ImageIO.getImageWritersByFormatName("jpg").next()
+                val param = writer.defaultWriteParam.apply {
+                    compressionMode = ImageWriteParam.MODE_EXPLICIT
+                    compressionQuality = LOSSY_IMAGE_QUALITY / 100f
+                }
+                FileImageOutputStream(this).use { outputStream ->
+                    writer.output = outputStream
+                    writer.write(null, IIOImage(image, null, null), param)
+                    writer.dispose()
+                }
+            }
+            ImageFormat.Png -> ImageIO.write(image, "png", this)
             ImageFormat.Webp -> error("DesktopPlatformRequest does not support WebP output")
         }
-        ImageIO.write(image, writerFormat, this)
     }
 
     private fun ImageFormat.toWritableFormat(): ImageFormat {
@@ -162,5 +194,10 @@ class DesktopPlatformRequest : PlatformRequest {
 
     private fun ByteArray.toHexString(): String {
         return joinToString(separator = "") { byte -> "%02x".format(byte.toInt() and 0xff) }
+    }
+
+    private companion object {
+        private const val MAX_IMAGE_DIMENSION = 1920
+        private const val LOSSY_IMAGE_QUALITY = 75
     }
 }

--- a/src/androidMain/kotlin/net/matsudamper/gptclient/AndroidPlatformRequest.android.kt
+++ b/src/androidMain/kotlin/net/matsudamper/gptclient/AndroidPlatformRequest.android.kt
@@ -76,7 +76,8 @@ class AndroidPlatformRequest(private val context: Context) : PlatformRequest {
             try {
                 val source = ImageDecoder.createSource(context.contentResolver, uri.toUri())
                 val bitmap = ImageDecoder.decodeBitmap(source)
-                val outputBitmap = cropRect?.let { bitmap.crop(it) } ?: bitmap
+                val outputBitmap = (cropRect?.let { bitmap.crop(it) } ?: bitmap)
+                    .resizeIfNeeded(MAX_IMAGE_DIMENSION)
                 val cacheKey = buildString {
                     append(uri)
                     append('|')
@@ -89,6 +90,10 @@ class AndroidPlatformRequest(private val context: Context) : PlatformRequest {
                     append(cropRect?.bottom)
                     append('|')
                     append(imageFormat.name)
+                    append('|')
+                    append(MAX_IMAGE_DIMENSION)
+                    append('|')
+                    append(LOSSY_IMAGE_QUALITY)
                 }.sha256Hex()
                 val file = File(context.cacheDir, "$cacheKey.${imageFormat.fileExtension}")
 
@@ -114,6 +119,14 @@ class AndroidPlatformRequest(private val context: Context) : PlatformRequest {
         val notificationManager: NotificationManager =
             context.getSystemService(android.content.Context.NOTIFICATION_SERVICE) as NotificationManager
         notificationManager.createNotificationChannel(channel)
+    }
+
+    private fun Bitmap.resizeIfNeeded(maxDimension: Int): Bitmap {
+        if (width <= maxDimension && height <= maxDimension) return this
+        val scale = maxDimension.toFloat() / maxOf(width, height)
+        val newWidth = (width * scale).toInt()
+        val newHeight = (height * scale).toInt()
+        return Bitmap.createScaledBitmap(this, newWidth, newHeight, true)
     }
 
     private fun Bitmap.crop(cropRect: PlatformRequest.CropRect): Bitmap {
@@ -182,6 +195,7 @@ class AndroidPlatformRequest(private val context: Context) : PlatformRequest {
     }
 
     private companion object {
-        private const val LOSSY_IMAGE_QUALITY = 85
+        private const val MAX_IMAGE_DIMENSION = 1920
+        private const val LOSSY_IMAGE_QUALITY = 75
     }
 }


### PR DESCRIPTION
## Summary
This PR implements image resizing to enforce a maximum dimension limit and improves JPEG compression handling across both desktop and Android platforms. Images exceeding the maximum dimension are now automatically resized before processing, and JPEG compression quality is explicitly controlled.

## Key Changes
- **Image Resizing**: Added `resizeIfNeeded()` function to both desktop and Android implementations that scales images down if they exceed `MAX_IMAGE_DIMENSION` (1920px), maintaining aspect ratio
  - Desktop: Uses `Graphics2D` with bilinear interpolation for high-quality resizing
  - Android: Uses `Bitmap.createScaledBitmap()` with filtering enabled
- **JPEG Compression**: Refactored desktop JPEG writing to use explicit `ImageWriteParam` with quality control instead of relying on default settings
- **Cache Key Updates**: Updated cache key generation to include `MAX_IMAGE_DIMENSION` and `LOSSY_IMAGE_QUALITY` constants, ensuring cache invalidation when these parameters change
- **Quality Standardization**: Unified `LOSSY_IMAGE_QUALITY` to 75 across both platforms (previously 85 on Android)

## Implementation Details
- The resize operation is applied after cropping but before format conversion
- Desktop JPEG writing now uses `FileImageOutputStream` with explicit writer configuration for better control
- Both platforms use the same `MAX_IMAGE_DIMENSION` constant (1920) for consistency
- The cache key now includes dimension and quality parameters to prevent serving outdated cached images when these settings change

https://claude.ai/code/session_01X7NSX7uAhHsT9ECEhwD7q2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * 画像処理が最適化されました。大きな画像は自動的に最適なサイズへリサイズされます。
  * 画像圧縮処理を改善し、より効率的なファイル処理を実現しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->