### PR TITLE
Gemini 3.1 Flash LiteのモデルIDをpreviewから正式版に更新

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -71,8 +71,8 @@ jobs:
         if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: apk-qr-code-github
           path: qrcode-github.png
+          archive: false
       - name: Generate S3 QR code
         if: github.event_name == 'pull_request' && steps.upload_s3.outputs.url != ''
         run: |
@@ -82,8 +82,8 @@ jobs:
         if: github.event_name == 'pull_request' && steps.upload_s3.outputs.url != ''
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: apk-qr-code-s3
           path: qrcode-s3.png
+          archive: false
       - name: Comment APK download URL
         if: github.event_name == 'pull_request'
         uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4

--- a/src/commonMain/kotlin/net/matsudamper/gptclient/entity/ChatGptModel.kt
+++ b/src/commonMain/kotlin/net/matsudamper/gptclient/entity/ChatGptModel.kt
@@ -81,7 +81,7 @@ interface ChatGptModel {
             data object Gemini3FlashLite : Gemini {
                 override val modelKey: String = "gemini-3.1-flash-lite-preview"
                 override val displayName: String = "Gemini 3.1 Flash Lite"
-                override val apiModelName: String = "gemini-3.1-flash-lite-preview"
+                override val apiModelName: String = "gemini-3.1-flash-lite"
                 override val enableImage: Boolean = true
                 override val defaultToken = 5000
                 override val requireTemperature = 1.0
@@ -98,7 +98,7 @@ interface ChatGptModel {
             data object Gemini3FlashLiteThinking : Gemini {
                 override val modelKey: String = "gemini-3.1-flash-lite-preview-thinking"
                 override val displayName: String = "Gemini 3.1 Flash Lite"
-                override val apiModelName: String = "gemini-3.1-flash-lite-preview"
+                override val apiModelName: String = "gemini-3.1-flash-lite"
                 override val enableImage: Boolean = true
                 override val defaultToken = 5000
                 override val requireTemperature = 1.0


### PR DESCRIPTION
gemini-3.1-flash-lite-previewのpreviewが終了したため、
modelKeyとapiModelNameをgemini-3.1-flash-liteに変更する。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * Gemini 3.1 Flash Lite および Gemini 3.1 Flash Lite Thinking のモデル識別子から「プレビュー」表記を削除し、安定版の識別子へ更新しました。

* **雑務（CI）**
  * プルリク用のQR画像生成とアップロード処理を調整し、QR画像のアーティファクト設定を簡素化しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/matsudamper/ai-client/pull/138)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->