### PR TITLE
AGP・compileSdk/targetSdk・依存ライブラリを最新版に更新

### DIFF
--- a/build-logic/libs.versions.toml
+++ b/build-logic/libs.versions.toml
@@ -1,29 +1,29 @@
 [versions]
 kotlin = "2.3.20"
-agp = "9.0.0-alpha06"
-androidCompileSdk = "36"
+agp = "9.1.1"
+androidCompileSdk = "37"
 androidMinSdk = "34"
-androidTargetSdk = "36"
-compose = "1.11.0-SNAPSHOT+ok-check-kotlin-2-3-20"
-androidxComposeUiToolingPreview = "1.10.6"
-jetbrainsComposeUiToolingPreview = "1.10.3"
+androidTargetSdk = "37"
+compose = "1.11.0"
+androidxComposeUiToolingPreview = "1.11.3"
+jetbrainsComposeUiToolingPreview = "1.11.0"
 composeIcons = "1.7.3"
 activity = "1.13.0"
-lifecycle = "2.10.0"
+lifecycle = "2.11.0"
 lifecycleViewmodelNav3 = "2.10.0"
 room = "2.8.4"
 ksp = "2.3.6"
-coroutine = "1.10.2"
+coroutine = "1.11.0"
 koin = "4.2.1"
 kotlinSerialization = "1.11.0"
-coil = "3.4.0"
+coil = "3.5.0"
 zoomable = "2.11.1"
 ktlintGradle = "14.2.0"
 ktlint = "1.6.0"
 workManager = "2.11.2"
 litertlm = "0.10.0"
 androidxTestRules = "1.7.0"
-nav3Ui = "1.0.0-alpha05"
+nav3Ui = "1.1.1"
 paparazzi = "2.0.0-alpha04"
 composablePreviewScanner = "0.8.2"
 
@@ -43,7 +43,7 @@ paparazzi = { id = "app.cash.paparazzi", version.ref = "paparazzi" }
 [libraries]
 androidActivityActivityCompose = { module = "androidx.activity:activity-compose", version.ref = "activity" }
 androidActivityKtx = { module = "androidx.activity:activity-ktx", version.ref = "activity" }
-androidxCoreKtx = { module = "androidx.core:core-ktx", version.require = "1.18.0" }
+androidxCoreKtx = { module = "androidx.core:core-ktx", version.require = "1.19.0" }
 androidxLifecycleViewModelKtx = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "lifecycle" }
 androidxLifecycleViewModelCompose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycle" }
 androidxLifecycleRuntimeCompose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "lifecycle" }
@@ -56,9 +56,9 @@ ktlint = { module = "com.pinterest:ktlint", version.ref = "ktlint" }
 androidxWorkRuntime = { module = "androidx.work:work-runtime-ktx", version.ref = "workManager" }
 
 # ktor
-ktorClientCore = { module = "io.ktor:ktor-client-core", version.require = "3.4.2" }
-ktorClientCio = { module = "io.ktor:ktor-client-cio", version.require = "3.4.2" }
-ktorClientLogging = { module = "io.ktor:ktor-client-logging", version.require = "3.4.2" }
+ktorClientCore = { module = "io.ktor:ktor-client-core", version.require = "3.5.0" }
+ktorClientCio = { module = "io.ktor:ktor-client-cio", version.require = "3.5.0" }
+ktorClientLogging = { module = "io.ktor:ktor-client-logging", version.require = "3.5.0" }
 
 # Coil
 coil3Compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil" }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     alias(libs.plugins.kotlinSerialization)
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.ktlingGradle) apply false
+    alias(libs.plugins.jetbrainsCompose)
     alias(libs.plugins.composeCompiler)
 }
 
@@ -49,12 +50,12 @@ kotlin {
                 api(projects.room)
                 api(projects.feature.localModel)
                 implementation(libs.androidxRoomRuntime)
-                implementation(libs.composeRuntime)
-                implementation(libs.composeUi)
-                implementation(libs.composeMaterial3)
-                implementation(libs.composeMaterial)
+                implementation(compose.runtime)
+                implementation(compose.ui)
+                implementation(compose.material3)
+                implementation(compose.material)
                 implementation(libs.composeMaterialIconsExtended)
-                implementation(libs.composeFoundation)
+                implementation(compose.foundation)
                 implementation(libs.composeIcons)
                 implementation(libs.navigation3Ui)
                 implementation(libs.lifecycleViewmodelNavigation3)
@@ -70,17 +71,17 @@ kotlin {
         }
         val jvmMain by getting {
             dependencies {
-                implementation(libs.composeUi)
-                implementation(libs.composeMaterial3)
+                implementation(compose.ui)
+                implementation(compose.material3)
                 implementation(libs.kotlinxCoroutineSwing)
                 implementation(libs.koinCore)
             }
         }
         val androidMain by getting {
             dependencies {
-                api(libs.composeRuntime)
-                api(libs.composeUi)
-                api(libs.composeMaterial3)
+                api(compose.runtime)
+                api(compose.ui)
+                api(compose.material3)
                 api(libs.androidActivityActivityCompose)
                 api(libs.androidActivityKtx)
                 api(libs.androidxCoreKtx)
@@ -88,7 +89,7 @@ kotlin {
                 api(libs.androidxLifecycleViewModelCompose)
                 api(libs.androidxLifecycleRuntimeCompose)
                 api(libs.googleMaterial)
-                api(libs.composeFoundation)
+                api(compose.foundation)
                 api(libs.koinAndroid)
                 api(libs.koinCore)
             }

--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -22,7 +22,7 @@ kotlin {
                 implementation(compose.ui)
                 implementation(compose.uiUtil)
                 implementation(compose.material3)
-                implementation(libs.composeMaterial)
+                implementation(compose.material)
                 implementation(libs.composeMaterialIconsExtended)
                 implementation(compose.foundation)
                 implementation(libs.composeIcons)


### PR DESCRIPTION
## 概要
AGP、compileSdk/targetSdk、および各種依存ライブラリを最新版に更新しました。
Compose Multiplatformのstable版移行に伴い、`compose.*`アクセサへの移行も実施しています。

## バージョン変更一覧

| ライブラリ | 変更前 | 変更後 |
|---|---|---|
| AGP | 9.0.0-alpha06 | 9.1.1 |
| compileSdk / targetSdk | 36 | 37 |
| Compose Multiplatform | 1.11.0-SNAPSHOT | 1.11.0 (stable) |
| Lifecycle | 2.10.0 | 2.11.0 |
| Navigation3 UI | 1.0.0-alpha05 | 1.1.1 |
| Coroutines | 1.10.2 | 1.11.0 |
| Coil | 3.4.0 | 3.5.0 |
| Ktor | 3.4.2 | 3.5.0 |
| Core KTX | 1.18.0 | 1.19.0 |
| AndroidX Compose UI Tooling Preview | 1.10.6 | 1.11.3 |
| JetBrains Compose UI Tooling Preview | 1.10.3 | 1.11.0 |

## ビルド設定の変更
- ルートプロジェクトに`jetbrainsCompose`プラグインを追加
- Composeライブラリの依存を`libs.*`から`compose.*`アクセサに移行（runtime, ui, material3, material, foundation）

## 据え置き
- **Kotlin**: 2.3.20 — KSPがKotlin 2.4.0未対応のため
- **KSP / Room / Koin / kotlinx-serialization / WorkManager**: すべて既に最新

https://claude.ai/code/session_01PYZKfwSaBX1WbyLXjub5hc