### PR TITLE
Add dynamic app shortcuts for recently used projects

### DIFF
--- a/app-android/src/main/kotlin/net/matsudamper/gptclient/Application.kt
+++ b/app-android/src/main/kotlin/net/matsudamper/gptclient/Application.kt
@@ -3,6 +3,8 @@ package net.matsudamper.gptclient
 import android.app.Application
 import android.content.Context
 import androidx.work.WorkManager
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
 import net.matsudamper.gptclient.datastore.AndroidSettingsEncryptor
 import net.matsudamper.gptclient.datastore.SettingDataStore
 import net.matsudamper.gptclient.datastore.SettingsEncryptor
@@ -17,6 +19,8 @@ import org.koin.core.context.startKoin
 import org.koin.dsl.module
 
 class Application : Application() {
+    private val applicationScope = CoroutineScope(SupervisorJob())
+
     override fun onCreate() {
         super.onCreate()
 
@@ -51,5 +55,11 @@ class Application : Application() {
         val platformRequest = get<PlatformRequest>()
         platformRequest.createNotificationChannel(GPT_CLIENT_NOTIFICATION_CHANNEL_ID)
         platformRequest.createNotificationChannel(LOCAL_MODEL_DOWNLOAD_NOTIFICATION_CHANNEL_ID)
+
+        ProjectShortcutPublisher(
+            context = applicationContext,
+            appDatabase = get(),
+            settingDataStore = get(),
+        ).start(applicationScope)
     }
 }

--- a/app-android/src/main/kotlin/net/matsudamper/gptclient/MainActivity.kt
+++ b/app-android/src/main/kotlin/net/matsudamper/gptclient/MainActivity.kt
@@ -12,7 +12,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.core.content.ContextCompat
 import net.matsudamper.gptclient.localmodel.EXTRA_OPEN_LOCAL_MODEL_SETTINGS
 import net.matsudamper.gptclient.navigation.Navigator
+import net.matsudamper.gptclient.room.entity.BuiltinProjectId
 import net.matsudamper.gptclient.room.entity.ChatRoomId
+import net.matsudamper.gptclient.room.entity.ProjectId
 import org.koin.android.ext.android.getKoin
 import org.koin.dsl.module
 
@@ -63,16 +65,36 @@ class MainActivity : ComponentActivity() {
     private fun createLaunchNavigationRequest(intent: Intent): LaunchNavigationRequest {
         val navigator = when {
             intent.getBooleanExtra(EXTRA_OPEN_LOCAL_MODEL_SETTINGS, false) -> Navigator.Settings
-            else -> getChatRoomIdFromIntent(intent)?.let { chatRoomId ->
-                Navigator.Chat(
-                    openContext = Navigator.Chat.ChatOpenContext.OpenChat(chatRoomId),
-                )
-            }
+            else -> getProjectNavigatorFromIntent(intent)
+                ?: getChatRoomIdFromIntent(intent)?.let { chatRoomId ->
+                    Navigator.Chat(
+                        openContext = Navigator.Chat.ChatOpenContext.OpenChat(chatRoomId),
+                    )
+                }
         }
         return LaunchNavigationRequest(
             id = System.nanoTime(),
             navigator = navigator,
         )
+    }
+
+    private fun getProjectNavigatorFromIntent(intent: Intent): Navigator.Project? {
+        val title = intent.getStringExtra(EXTRA_SHORTCUT_PROJECT_TITLE) ?: return null
+        val builtinProjectId = intent.getStringExtra(EXTRA_SHORTCUT_BUILTIN_PROJECT_ID)
+        if (builtinProjectId != null) {
+            return Navigator.Project(
+                title = title,
+                type = Navigator.Project.ProjectType.Builtin(BuiltinProjectId(builtinProjectId)),
+            )
+        }
+        val projectId = intent.getLongExtra(EXTRA_SHORTCUT_PROJECT_ID, -1L)
+        if (projectId >= 0L) {
+            return Navigator.Project(
+                title = title,
+                type = Navigator.Project.ProjectType.Project(ProjectId(projectId)),
+            )
+        }
+        return null
     }
 
     private fun getChatRoomIdFromIntent(intent: Intent): ChatRoomId? {

--- a/app-android/src/main/kotlin/net/matsudamper/gptclient/ProjectShortcutPublisher.kt
+++ b/app-android/src/main/kotlin/net/matsudamper/gptclient/ProjectShortcutPublisher.kt
@@ -1,0 +1,121 @@
+package net.matsudamper.gptclient
+
+import android.content.Context
+import android.content.Intent
+import androidx.core.content.pm.ShortcutInfoCompat
+import androidx.core.content.pm.ShortcutManagerCompat
+import androidx.core.graphics.drawable.IconCompat
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.launch
+import net.matsudamper.gptclient.app.R
+import net.matsudamper.gptclient.datastore.SettingDataStore
+import net.matsudamper.gptclient.entity.Calendar
+import net.matsudamper.gptclient.entity.Emoji
+import net.matsudamper.gptclient.entity.Money
+import net.matsudamper.gptclient.entity.getProjectTitle
+import net.matsudamper.gptclient.entity.projectUsageKey
+import net.matsudamper.gptclient.room.AppDatabase
+import net.matsudamper.gptclient.room.entity.BuiltinProjectId
+import net.matsudamper.gptclient.room.entity.Project
+
+const val EXTRA_SHORTCUT_BUILTIN_PROJECT_ID = "shortcutBuiltinProjectId"
+const val EXTRA_SHORTCUT_PROJECT_ID = "shortcutProjectId"
+const val EXTRA_SHORTCUT_PROJECT_TITLE = "shortcutProjectTitle"
+
+class ProjectShortcutPublisher(
+    private val context: Context,
+    private val appDatabase: AppDatabase,
+    private val settingDataStore: SettingDataStore,
+) {
+    fun start(scope: CoroutineScope) {
+        scope.launch(Dispatchers.Default) {
+            combine(
+                appDatabase.projectDao().getAll(),
+                settingDataStore.getProjectLastUsedAtFlow(),
+            ) { projects, lastUsedAt ->
+                createEntries(
+                    projects = projects,
+                    lastUsedAt = lastUsedAt,
+                )
+            }.distinctUntilChanged().collectLatest { entries ->
+                publish(entries)
+            }
+        }
+    }
+
+    private fun createEntries(
+        projects: List<Project>,
+        lastUsedAt: Map<String, Long>,
+    ): List<Entry> {
+        val builtinEntries = listOf(
+            BuiltinProjectId.Calendar,
+            BuiltinProjectId.Money,
+            BuiltinProjectId.Emoji,
+        ).map { builtinProjectId ->
+            Entry(
+                key = projectUsageKey(builtinProjectId),
+                label = builtinProjectId.getProjectTitle(),
+                target = Entry.Target.Builtin(builtinProjectId),
+            )
+        }
+        val projectEntries = projects.map { project ->
+            Entry(
+                key = projectUsageKey(project.id),
+                label = project.name,
+                target = Entry.Target.UserProject(project),
+            )
+        }
+        val maxCount = minOf(
+            MAX_SHORTCUT_COUNT,
+            ShortcutManagerCompat.getMaxShortcutCountPerActivity(context),
+        )
+        return builtinEntries.plus(projectEntries)
+            .sortedByDescending { lastUsedAt[it.key] ?: 0L }
+            .take(maxCount)
+    }
+
+    private fun publish(entries: List<Entry>) {
+        val shortcuts = entries.mapIndexed { index, entry ->
+            val intent = Intent(context, MainActivity::class.java).apply {
+                action = Intent.ACTION_VIEW
+                putExtra(EXTRA_SHORTCUT_PROJECT_TITLE, entry.label)
+                when (val target = entry.target) {
+                    is Entry.Target.Builtin -> {
+                        putExtra(EXTRA_SHORTCUT_BUILTIN_PROJECT_ID, target.builtinProjectId.id)
+                    }
+
+                    is Entry.Target.UserProject -> {
+                        putExtra(EXTRA_SHORTCUT_PROJECT_ID, target.project.id.id)
+                    }
+                }
+            }
+            ShortcutInfoCompat.Builder(context, entry.key)
+                .setShortLabel(entry.label)
+                .setLongLabel(entry.label)
+                .setIcon(IconCompat.createWithResource(context, R.mipmap.ic_app_icon))
+                .setRank(index)
+                .setIntent(intent)
+                .build()
+        }
+        ShortcutManagerCompat.setDynamicShortcuts(context, shortcuts)
+    }
+
+    private data class Entry(
+        val key: String,
+        val label: String,
+        val target: Target,
+    ) {
+        sealed interface Target {
+            data class Builtin(val builtinProjectId: BuiltinProjectId) : Target
+            data class UserProject(val project: Project) : Target
+        }
+    }
+
+    companion object {
+        private const val MAX_SHORTCUT_COUNT = 4
+    }
+}

--- a/src/commonMain/kotlin/net/matsudamper/gptclient/datastore/SettingDataStore.kt
+++ b/src/commonMain/kotlin/net/matsudamper/gptclient/datastore/SettingDataStore.kt
@@ -58,4 +58,10 @@ class SettingDataStore(
     }
 
     fun getActiveLocalModelKeysFlow(): Flow<Set<LocalModelId>> = store.data.map { it.activeLocalModelKeys.toLocalModelIds() }
+
+    suspend fun recordProjectUsage(key: String, usedAt: Long) {
+        store.updateData { it.copy(projectLastUsedAt = it.projectLastUsedAt + (key to usedAt)) }
+    }
+
+    fun getProjectLastUsedAtFlow(): Flow<Map<String, Long>> = store.data.map { it.projectLastUsedAt }
 }

--- a/src/commonMain/kotlin/net/matsudamper/gptclient/datastore/Settings.kt
+++ b/src/commonMain/kotlin/net/matsudamper/gptclient/datastore/Settings.kt
@@ -12,6 +12,7 @@ data class Settings(
     @ProtoNumber(3) val themeMode: ThemeMode = ThemeMode.SYSTEM,
     @ProtoNumber(4) val geminiBillingKey: String = "",
     @ProtoNumber(5) val activeLocalModelKeys: Set<String> = emptySet(),
+    @ProtoNumber(6) val projectLastUsedAt: Map<String, Long> = emptyMap(),
 )
 
 @Serializable

--- a/src/commonMain/kotlin/net/matsudamper/gptclient/entity/BuiltinProjectIdExt.kt
+++ b/src/commonMain/kotlin/net/matsudamper/gptclient/entity/BuiltinProjectIdExt.kt
@@ -11,6 +11,13 @@ val BuiltinProjectId.Companion.Money
 val BuiltinProjectId.Companion.Emoji
     get() = BuiltinProjectId("emoji")
 
+fun BuiltinProjectId.getProjectTitle(): String = when (this) {
+    BuiltinProjectId.Calendar -> "カレンダー追加"
+    BuiltinProjectId.Money -> "家計簿追加"
+    BuiltinProjectId.Emoji -> "絵文字"
+    else -> throw NotImplementedError("Not yet implemented ${this.id}")
+}
+
 fun BuiltinProjectId.getName(): String = when (this) {
     BuiltinProjectId.Calendar -> "カレンダー"
     BuiltinProjectId.Money -> "家計簿"

--- a/src/commonMain/kotlin/net/matsudamper/gptclient/entity/ProjectUsageKey.kt
+++ b/src/commonMain/kotlin/net/matsudamper/gptclient/entity/ProjectUsageKey.kt
@@ -1,0 +1,8 @@
+package net.matsudamper.gptclient.entity
+
+import net.matsudamper.gptclient.room.entity.BuiltinProjectId
+import net.matsudamper.gptclient.room.entity.ProjectId
+
+fun projectUsageKey(builtinProjectId: BuiltinProjectId): String = "builtin:${builtinProjectId.id}"
+
+fun projectUsageKey(projectId: ProjectId): String = "project:${projectId.id}"

--- a/src/commonMain/kotlin/net/matsudamper/gptclient/viewmodel/NewChatViewModel.kt
+++ b/src/commonMain/kotlin/net/matsudamper/gptclient/viewmodel/NewChatViewModel.kt
@@ -16,6 +16,7 @@ import net.matsudamper.gptclient.entity.Calendar
 import net.matsudamper.gptclient.entity.ChatGptModel
 import net.matsudamper.gptclient.entity.Emoji
 import net.matsudamper.gptclient.entity.Money
+import net.matsudamper.gptclient.entity.getProjectTitle
 import net.matsudamper.gptclient.localmodel.LocalModelDefinition
 import net.matsudamper.gptclient.localmodel.LocalModelId
 import net.matsudamper.gptclient.localmodel.LocalModelRepository
@@ -46,13 +47,13 @@ class NewChatViewModel(
     private val viewModelStateFlow = MutableStateFlow(ViewModelState())
     private val builtinProjects = listOf(
         NewChatUiState.Project(
-            name = "カレンダー追加",
+            name = BuiltinProjectId.Calendar.getProjectTitle(),
             icon = NewChatUiState.Project.Icon.Calendar,
             listener = object : NewChatUiState.Project.Listener {
                 override fun onClick() {
                     appNavigator.navigate(
                         Navigator.Project(
-                            title = "カレンダー追加",
+                            title = BuiltinProjectId.Calendar.getProjectTitle(),
                             type = Navigator.Project.ProjectType.Builtin(
                                 BuiltinProjectId.Calendar,
                             ),
@@ -62,13 +63,13 @@ class NewChatViewModel(
             },
         ),
         NewChatUiState.Project(
-            name = "家計簿追加",
+            name = BuiltinProjectId.Money.getProjectTitle(),
             icon = NewChatUiState.Project.Icon.Card,
             listener = object : NewChatUiState.Project.Listener {
                 override fun onClick() {
                     appNavigator.navigate(
                         Navigator.Project(
-                            title = "家計簿追加",
+                            title = BuiltinProjectId.Money.getProjectTitle(),
                             type = Navigator.Project.ProjectType.Builtin(
                                 BuiltinProjectId.Money,
                             ),
@@ -78,13 +79,13 @@ class NewChatViewModel(
             },
         ),
         NewChatUiState.Project(
-            name = "絵文字",
+            name = BuiltinProjectId.Emoji.getProjectTitle(),
             icon = NewChatUiState.Project.Icon.Emoji,
             listener = object : NewChatUiState.Project.Listener {
                 override fun onClick() {
                     appNavigator.navigate(
                         Navigator.Project(
-                            title = "絵文字",
+                            title = BuiltinProjectId.Emoji.getProjectTitle(),
                             type = Navigator.Project.ProjectType.Builtin(
                                 BuiltinProjectId.Emoji,
                             ),

--- a/src/commonMain/kotlin/net/matsudamper/gptclient/viewmodel/ProjectViewModel.kt
+++ b/src/commonMain/kotlin/net/matsudamper/gptclient/viewmodel/ProjectViewModel.kt
@@ -18,6 +18,7 @@ import net.matsudamper.gptclient.client.AiClient
 import net.matsudamper.gptclient.datastore.GeminiBillingKeyOverrideStore
 import net.matsudamper.gptclient.datastore.SettingDataStore
 import net.matsudamper.gptclient.entity.ChatGptModel
+import net.matsudamper.gptclient.entity.projectUsageKey
 import net.matsudamper.gptclient.localmodel.LocalModelDefinition
 import net.matsudamper.gptclient.localmodel.LocalModelId
 import net.matsudamper.gptclient.localmodel.LocalModelRepository
@@ -209,6 +210,16 @@ class ProjectViewModel(
             listener = listener,
         ),
     ).also { uiStateFlow ->
+        viewModelScope.launch {
+            val usageKey = when (val type = navigator.type) {
+                is Navigator.Project.ProjectType.Builtin -> projectUsageKey(type.builtinProjectId)
+                is Navigator.Project.ProjectType.Project -> projectUsageKey(type.projectId)
+            }
+            settingDataStore.recordProjectUsage(
+                key = usageKey,
+                usedAt = System.currentTimeMillis(),
+            )
+        }
         viewModelScope.launch {
             settingDataStore.getActiveLocalModelKeysFlow().collectLatest { activeKeys ->
                 viewModelStateFlow.update { it.copy(activeLocalModelKeys = activeKeys) }


### PR DESCRIPTION
## Summary
Implement dynamic app shortcuts that display the most recently used projects (both built-in and user-created) on the Android home screen. This improves user experience by providing quick access to frequently used projects.

## Key Changes
- **New `ProjectShortcutPublisher` class**: Monitors project usage and publishes dynamic shortcuts to the Android launcher
  - Tracks both built-in projects (Calendar, Money, Emoji) and user-created projects
  - Limits shortcuts to 4 items (or device maximum, whichever is lower)
  - Sorts by last usage time to show most recent projects first
  - Updates shortcuts reactively when project data or usage patterns change

- **Project usage tracking**: 
  - Added `recordProjectUsage()` method to `SettingDataStore` to log when projects are accessed
  - Added `getProjectLastUsedAtFlow()` to retrieve usage history
  - Extended `Settings` proto to persist `projectLastUsedAt` map
  - Created `projectUsageKey()` helper functions to generate consistent keys for built-in and user projects

- **Intent handling in MainActivity**:
  - Added `getProjectNavigatorFromIntent()` to extract project information from shortcut intents
  - Routes shortcut taps to the appropriate project view with title and type information

- **UI consistency**:
  - Extracted `getProjectTitle()` extension function for built-in projects
  - Updated `NewChatViewModel` to use centralized project titles instead of hardcoded strings
  - Ensures consistent naming across shortcuts, UI, and navigation

- **Application initialization**:
  - Initialize `ProjectShortcutPublisher` in `Application.onCreate()` with application-scoped coroutine
  - Ensures shortcuts are kept up-to-date throughout app lifecycle

## Implementation Details
- Uses `ShortcutManagerCompat` for backward compatibility with older Android versions
- Reactive flow-based architecture automatically updates shortcuts when projects or usage data changes
- Shortcuts include project title, icon, and navigation intent with project metadata
- Usage tracking is recorded when a project is opened via `ProjectViewModel`

https://claude.ai/code/session_01NWJfWZXyTYXTiqbQUkTstn