### PR TITLE
Remove unused Compose Material dependency

### DIFF
--- a/build-logic/libs.versions.toml
+++ b/build-logic/libs.versions.toml
@@ -95,7 +95,6 @@ composeRuntime = { module = "org.jetbrains.compose.runtime:runtime", version.ref
 composeUi = { module = "org.jetbrains.compose.ui:ui", version.ref = "compose" }
 composeFoundation = { module = "org.jetbrains.compose.foundation:foundation", version.ref = "compose" }
 composeMaterial3 = { module = "org.jetbrains.compose.material3:material3", version.ref = "compose" }
-composeMaterial = { module = "org.jetbrains.compose.material:material", version.ref = "compose" }
 composeMaterialIconsExtended = { module = "org.jetbrains.compose.material:material-icons-extended", version.ref = "composeIcons" }
 composeUiUtil = { module = "org.jetbrains.compose.ui:ui-util", version.ref = "compose" }
 composeComponentsResources = { module = "org.jetbrains.compose.components:components-resources", version.ref = "compose" }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,7 +53,6 @@ kotlin {
                 implementation(compose.runtime)
                 implementation(compose.ui)
                 implementation(compose.material3)
-                implementation(compose.material)
                 implementation(libs.composeMaterialIconsExtended)
                 implementation(compose.foundation)
                 implementation(libs.composeIcons)

--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -22,7 +22,6 @@ kotlin {
                 implementation(compose.ui)
                 implementation(compose.uiUtil)
                 implementation(compose.material3)
-                implementation(compose.material)
                 implementation(libs.composeMaterialIconsExtended)
                 implementation(compose.foundation)
                 implementation(libs.composeIcons)


### PR DESCRIPTION
## Summary
Remove the deprecated Compose Material library dependency across the project, as Material3 is now the standard UI component library.

## Changes
- Removed `composeMaterial` library definition from `build-logic/libs.versions.toml`
- Removed `compose.material` implementation from root `build.gradle.kts`
- Removed `compose.material` implementation from `ui/build.gradle.kts`

## Details
The Compose Material (v1) library is no longer needed as the project has migrated to Material3 for all UI components. This cleanup removes the unused dependency declarations while keeping Material Icons Extended, which remains a separate dependency.

https://claude.ai/code/session_012XufD1YsNbYTZKMS1TXAEw