### PR TITLE
AndroidテーマをMaterial3に移行

### DIFF
--- a/app-android/src/main/res/values/themes.xml
+++ b/app-android/src/main/res/values/themes.xml
@@ -1,4 +1,4 @@
 <resources>
-    <style name="Theme.Main" parent="Theme.AppCompat.DayNight.NoActionBar">
+    <style name="Theme.Main" parent="Theme.Material3.DayNight.NoActionBar">
     </style>
 </resources>


### PR DESCRIPTION
app-androidのThemeがTheme.AppCompat.DayNight.NoActionBarを
継承していたため、Theme.Material3.DayNight.NoActionBarに変更。
Compose側はすでにmaterial3のみを使用していたため、これで
Material2/AppCompat系のテーマ・コンポーネントへの依存がなくなった。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **スタイル**
  * アプリのテーマを Material 3 ベースに更新し、より新しいデザイン基準に対応しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->